### PR TITLE
Catch and ignore more demangling errors

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,8 @@
 from binaryninja import PluginCommand
 from rust_demangler import demangle
 from rust_demangler.rust import TypeNotFoundError
+from rust_demangler.rust_legacy import UnableToLegacyDemangle
+from rust_demangler.rust_v0 import UnableTov0Demangle
 
 def demangle_functions(bv):
     for f in bv.functions:
@@ -8,6 +10,10 @@ def demangle_functions(bv):
             f.name = demangle(f.symbol.raw_name)
         # Not a valid mangled name
         except TypeNotFoundError:
+            pass
+        except UnableToLegacyDemangle:
+            pass
+        except UnableTov0Demangle:
             pass
 
 PluginCommand.register("Rust Demangle", "Demangles Rust symbols.", demangle_functions)


### PR DESCRIPTION
`rust_demangler.demangle` can throw `rust_demangler.{rust_legacy.UnableToLegacyDemangle, rust_v0.UnableTov0Demangle}` if the given symbol name has a prefix signifying the use of the respective mangling schemes but is not actually a valid mangled name.

For example, `Reset` from [`cortex_m_rt`](https://docs.rs/cortex-m-rt/0.6.13/cortex_m_rt/) is not a mangled name but has a prefix `R` which is specific to the v0 mangling scheme, so demangling it would produce an `UnableTov0Demangle` exception.