### PR TITLE
properly handle undo actions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,10 +1,12 @@
+from binaryninja import BinaryView
 from binaryninja import PluginCommand
 from rust_demangler import demangle
 from rust_demangler.rust import TypeNotFoundError
 from rust_demangler.rust_legacy import UnableToLegacyDemangle
 from rust_demangler.rust_v0 import UnableTov0Demangle
 
-def demangle_functions(bv):
+def demangle_functions(bv: BinaryView):
+    bv.begin_undo_actions()
     for f in bv.functions:
         try:
             f.name = demangle(f.symbol.raw_name)
@@ -15,5 +17,6 @@ def demangle_functions(bv):
             pass
         except UnableTov0Demangle:
             pass
+    bv.commit_undo_actions()
 
 PluginCommand.register("Rust Demangle", "Demangles Rust symbols.", demangle_functions)


### PR DESCRIPTION
This change prevents Binja from complaining about renames not being inside a proper undo action.