### PR TITLE
Handle imported Rust symbols

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,6 @@
 from binaryninja import BinaryView
 from binaryninja import PluginCommand
+from binaryninja import Symbol, SymbolType
 from rust_demangler import demangle
 from rust_demangler.rust import TypeNotFoundError
 from rust_demangler.rust_legacy import UnableToLegacyDemangle
@@ -17,6 +18,19 @@ def demangle_functions(bv: BinaryView):
             pass
         except UnableTov0Demangle:
             pass
+    for sym in bv.symbols.values():
+        for symbol in sym:
+            if symbol.type == SymbolType.ExternalSymbol:
+                try:
+                    user_sym = Symbol(symbol.type, symbol.address, demangle(symbol.raw_name))
+                except TypeNotFoundError:
+                    pass
+                except UnableToLegacyDemangle:
+                    pass
+                except UnableTov0Demangle:
+                    pass
+                bv.define_user_symbol(user_sym)
+
     bv.commit_undo_actions()
 
 PluginCommand.register("Rust Demangle", "Demangles Rust symbols.", demangle_functions)


### PR DESCRIPTION
This allows imported symbols (e.g. in a Linux Kernel Module) to demangle properly