### PR TITLE
fix: properly handle failed symbol demangling

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -24,11 +24,11 @@ def demangle_functions(bv: BinaryView):
                 try:
                     user_sym = Symbol(symbol.type, symbol.address, demangle(symbol.raw_name))
                 except TypeNotFoundError:
-                    pass
+                    continue
                 except UnableToLegacyDemangle:
-                    pass
+                    continue
                 except UnableTov0Demangle:
-                    pass
+                    continue
                 bv.define_user_symbol(user_sym)
 
     bv.commit_undo_actions()


### PR DESCRIPTION
Using `pass` when handling exceptions still executes `bv.define_user_symbol()` in the event of an exception. `continue` allows us to skip to the next symbol to be demangled.